### PR TITLE
Optimize for updating existing installations

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -1,5 +1,7 @@
-#define MyJarPlugin "de.h-ab.ev3plugin_1.7.2.201605311139.jar"
+#define MyJarPluginBasename "de.h-ab.ev3plugin"
+#define MyJarPlugin "de.h-ab.ev3plugin_1.7.2.201908011455.jar"
 #define MyGCCInstaller "arm-2009q1-203-arm-none-linux-gnueabi.exe"
+#define BuildDir "D:\build"
 ;#define TOOLCHAIN_INCLUDED
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.
@@ -31,14 +33,19 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 [Files]
 ; Toolchain
 #ifdef TOOLCHAIN_INCLUDED
-Source: "D:\ev3\{#MyGCCInstaller}"; DestDir: "{app}"; AfterInstall: InstallToolchain
+Source: "{#BuildDir}\{#MyGCCInstaller}"; DestDir: "{app}"; AfterInstall: InstallToolchain
 #endif
 ; API
-Source: "D:\ev3\API\*"; DestDir: "{app}\API"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#BuildDir}\API\*"; DestDir: "{app}\API"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; Uploader
-Source: "D:\ev3\uploader\*"; DestDir: "{app}\uploader"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#BuildDir}\uploader\*"; DestDir: "{app}\uploader"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; Plugin
-Source: "D:\ev3\{#MyJarPlugin}"; DestDir: "{app}"; AfterInstall: InstallPlugin
+Source: "{#BuildDir}\{#MyJarPlugin}"; DestDir: "{app}"; AfterInstall: InstallPlugin
+
+[InstallDelete]
+Type: filesandordirs; Name: "{app}\API"
+Type: filesandordirs; Name: "{app}\uploader"
+
 [Code]
 var
   EclipseDirectory: String;
@@ -81,6 +88,9 @@ begin
              , mbInformation, MB_OK)
   else
       EclipseDirectory := directory;
+
+      DelTree(directory + ExpandConstant('\dropins\{#MyJarPluginBasename}*.jar'), False, True, True);
+
       FileCopy(ExpandConstant('{app}\{#MyJarPlugin}'),
                directory + ExpandConstant('\dropins\{#MyJarPlugin}'), false);
 end;


### PR DESCRIPTION
InstallDelete API and uploader directory.
Delete the plugin from dropin to avoid having two versions installed.
This should allow for updating by just installing over an existing
installation.